### PR TITLE
Expose multi-channel backprojection via Python wrapper

### DIFF
--- a/CustomOperators/multi_channel_backprojection/README.md
+++ b/CustomOperators/multi_channel_backprojection/README.md
@@ -1,0 +1,71 @@
+# Multi-channel backprojection operator
+
+This folder contains a standalone CUDA implementation that extends TIGRE's
+`voxel_backprojection` routine to handle multi-channel (e.g. spectral) projection
+stacks in a single GPU launch. The host function exposed by
+[`multi_channel_backprojection.hpp`](multi_channel_backprojection.hpp) is:
+
+```c++
+int voxel_backprojection_multi_channel(
+    float* projections,
+    Geometry geo,
+    float* result,
+    float const* const alphas,
+    int nalpha,
+    int nChannels,
+    const GpuIds& gpuids);
+```
+
+## Data layout
+
+To maximise reuse of the original kernels, both the projection and the volume
+arrays must be stored in contiguous **C-order** memory with the following
+strides:
+
+* `projections[(angle * nChannels + channel) * nDetecV * nDetecU + v * nDetecU + u]`
+* `result[(channel * nVoxelZ + z) * nVoxelY * nVoxelX + y * nVoxelX + x]`
+
+This matches the layout you would obtain by stacking channels as the innermost
+dimension when using NumPy/Python.
+
+## Building
+
+The source is intentionally independent from the Python build system. You can
+compile it into a static library or an object file using `nvcc`. A minimal
+example (run from the repository root) that produces an object file is:
+
+```bash
+nvcc -std=c++14 -ICommon/CUDA -ICustomOperators/multi_channel_backprojection \
+     -c CustomOperators/multi_channel_backprojection/multi_channel_backprojection.cu \
+     -o build/multi_channel_backprojection.o
+```
+
+You may need to create the `build/` directory first. Link the resulting object
+file (or library) together with TIGRE's existing CUDA sources when building a
+Python extension or a custom executable.
+
+## Python binding and verification
+
+A dedicated Cython wrapper is shipped with the repository so the operator is
+available directly from Python once TIGRE is built in editable mode:
+
+```bash
+pip install -e .
+```
+
+This exposes `tigre.Atb_multi_channel`, which accepts a projection tensor with
+layout `(n_angles, n_channels, nDetecV, nDetecU)` (or `(n_channels, n_angles, …)`
+when passing `layout="channels_angles"`). The helper mirrors the single-channel
+API and returns either `(channels, Z, Y, X)` or `(channels, X, Y, Z)` depending
+on `output_order`.
+
+The [`example_compare.py`](example_compare.py) script reproduces the workflow
+from the user request and ensures the multi-channel implementation matches a
+serial Python loop over `tigre.Atb`:
+
+```bash
+python CustomOperators/multi_channel_backprojection/example_compare.py
+```
+
+The script prints the execution time for both approaches and finishes with an
+`assert_allclose` check that the results are numerically identical.

--- a/CustomOperators/multi_channel_backprojection/example_compare.py
+++ b/CustomOperators/multi_channel_backprojection/example_compare.py
@@ -1,0 +1,117 @@
+"""Compare TIGRE's single-channel backprojector with the multi-channel CUDA operator.
+
+This script mirrors the workflow shared by the user: we construct a synthetic
+volume, generate projections, and validate that the multi-channel operator
+matches looping over ``tigre.Atb`` channel by channel.
+
+The script expects a CUDA-capable environment with TIGRE compiled in-place
+(``pip install -e .`` from the repository root).
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+import tigre
+from tigre.utilities.Atb_multi_channel import Atb_multi_channel
+
+
+class ConeGeometrySpecial(tigre.utilities.geometry.Geometry):
+    """Minimal cone-beam geometry helper using millimetre inputs."""
+
+    def __init__(self, config: dict[str, float]) -> None:
+        super().__init__()
+        self.DSD = config["DSD"] / 1000.0
+        self.DSO = config["DSO"] / 1000.0
+        self.nDetector = np.array(config["nDetector"], dtype=np.int32)
+        self.dDetector = np.array(config["dDetector"], dtype=np.float32) / 1000
+        self.sDetector = self.nDetector * self.dDetector
+        self.nVoxel = np.array(config["nVoxel"][::-1], dtype=np.int32)
+        self.dVoxel = np.array(config["dVoxel"][::-1], dtype=np.float32) / 1000
+        self.sVoxel = self.nVoxel * self.dVoxel
+        self.offOrigin = np.array(config["offOrigin"][::-1], dtype=np.float32) / 1000
+        self.offDetector = np.array(
+            [config["offDetector"][1], config["offDetector"][0], 0], dtype=np.float32
+        ) / 1000
+        self.accuracy = float(config["accuracy"])
+        self.mode = config["mode"]
+        self.filter = config.get("filter", "ram-lak")
+
+
+def atb_for_loop(projs: np.ndarray, geo, angles: np.ndarray) -> np.ndarray:
+    """Serial reference that calls :func:`tigre.Atb` channel by channel."""
+
+    outputs = []
+    for channel in range(projs.shape[0]):
+        backproj = tigre.Atb(projs[channel], geo, angles)
+        outputs.append(backproj.transpose(2, 1, 0))
+    return np.stack(outputs, axis=0)
+
+
+if __name__ == "__main__":
+    cfg = {
+        "DSD": 1200.0,
+        "DSO": 800.0,
+        "nDetector": [128, 128],
+        "dDetector": [1.0, 1.0],
+        "nVoxel": [64, 64, 64],
+        "dVoxel": [1.0, 1.0, 1.0],
+        "offOrigin": [0.0, 0.0, 0.0],
+        "offDetector": [0.0, 0.0],
+        "accuracy": 0.5,
+        "mode": "cone",
+        "filter": "ram-lak",
+        "n_projections": 60,
+        "total_angle": 360.0,
+        "start_angle": 0.0,
+    }
+
+    geo = ConeGeometrySpecial(cfg)
+    angles = (
+        np.linspace(
+            0,
+            cfg["total_angle"] / 180 * np.pi,
+            cfg["n_projections"],
+            endpoint=False,
+        )
+        + cfg["start_angle"] / 180 * np.pi
+    ).astype(np.float32)
+
+    nx, ny, nz = cfg["nVoxel"]
+    vol = np.zeros((nx, ny, nz), dtype=np.float32)
+    for (x, y, z) in [(32, 32, 32), (20, 40, 10), (45, 10, 55)]:
+        vol[x, y, z] = 0.1
+
+    vol_zyx = vol.transpose(2, 1, 0).copy()
+    projs_single = tigre.Ax(vol_zyx, geo, angles)
+    projs_single = projs_single[:, ::-1, :]
+
+    n_channels = 8
+    scales = np.linspace(0.5, 2.0, n_channels, dtype=np.float32).reshape(1, n_channels, 1, 1)
+    projs_multi = np.repeat(projs_single[:, np.newaxis, :, :], n_channels, axis=1) * scales
+
+    print("[Ax] projections:", projs_multi.shape)
+
+    start = time.time()
+    ref = atb_for_loop(projs_multi.transpose(1, 0, 2, 3), geo, angles)
+    loop_time = time.time() - start
+
+    start = time.time()
+    recon = Atb_multi_channel(
+        projs_multi.astype(np.float32),
+        geo,
+        angles,
+        layout="angles_channels",
+        output_order="channels_xyz",
+        vflip=True,
+    )
+    multi_time = time.time() - start
+
+    max_err = float(np.max(np.abs(ref - recon)))
+    print(f"Looped backprojection time: {loop_time:.3f} s")
+    print(f"Multi-channel backprojection time: {multi_time:.3f} s")
+    print("Maximum absolute difference:", max_err)
+    np.testing.assert_allclose(recon, ref, rtol=1e-5, atol=1e-5)
+    print("Validation passed.")

--- a/CustomOperators/multi_channel_backprojection/multi_channel_backprojection.cu
+++ b/CustomOperators/multi_channel_backprojection/multi_channel_backprojection.cu
@@ -1,0 +1,967 @@
+/*-------------------------------------------------------------------------
+ *
+ * CUDA function for backrpojection using FDK weigts for CBCT
+ *
+ *
+ * CODE by  Ander Biguri
+ *          Optimized and modified by RB
+ * ---------------------------------------------------------------------------
+ * ---------------------------------------------------------------------------
+ * Copyright (c) 2015, University of Bath and CERN- European Organization for
+ * Nuclear Research
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * ---------------------------------------------------------------------------
+ *
+ * Contact: tigre.toolbox@gmail.com
+ * Codes  : https://github.com/CERN/TIGRE
+ * ---------------------------------------------------------------------------
+ */
+
+#define  PI_2 1.57079632679489661923
+#include <algorithm>
+#include <cuda_runtime_api.h>
+#include <cuda.h>
+#include "multi_channel_backprojection.hpp"
+#include "TIGRE_common.hpp"
+#include <math.h>
+#include "GpuIds.hpp"
+
+// https://stackoverflow.com/questions/16282136/is-there-a-cuda-equivalent-of-perror
+#define cudaCheckErrors(msg) \
+do { \
+        cudaError_t __err = cudaGetLastError(); \
+        if (__err != cudaSuccess) { \
+                mexPrintf("%s \n",msg);\
+                mexErrMsgIdAndTxt("CBCT:CUDA:Atb",cudaGetErrorString(__err));\
+        } \
+} while (0)
+    
+    
+#define MAXTREADS 1024
+
+namespace tigre_mc_internal {
+    /*GEOMETRY DEFINITION
+     *
+     *                Detector plane, behind
+     *            |-----------------------------|
+     *            |                             |
+     *            |                             |
+     *            |                             |
+     *            |                             |
+     *            |      +--------+             |
+     *            |     /        /|             |
+     *   A Z      |    /        / |*D           |
+     *   |        |   +--------+  |             |
+     *   |        |   |        |  |             |
+     *   |        |   |     *O |  +             |
+     *   *--->y   |   |        | /              |
+     *  /         |   |        |/               |
+     * V X        |   +--------+                |
+     *            |-----------------------------|
+     *
+     *           *S
+     *
+     *
+     *
+     *
+     *
+     **/
+    
+    void CreateTextureMulti(const GpuIds& gpuids,float* projectiondata,Geometry geo,cudaArray** d_cuArrTex,unsigned int nangles, cudaTextureObject_t *texImage,cudaStream_t* stream, int nStreamDevice,bool allocate);
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// RB, 10/31/2016: Add constant memory arrays to store parameters for all projections to be analyzed during a single kernel call
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// The optimal values of two constants obtained by RB on NVIDIA Quadro K2200 (4 GB RAM, 640 CUDA cores) for 512^3 volume and 512^3 projections (512 proj, each 512 x 512) were:
+// PROJ_PER_KERNEL = 32 or 16 (very similar times)
+// VOXELS_PER_THREAD = 8
+// Speedup of the entire FDK backprojection (not only kernel run, also memcpy etc.) was nearly 4x relative to the original (single projection, single voxel per thread) code.
+// (e.g. 16.2 s vs. ~62 s).
+
+const int PROJ_PER_KERNEL = 32;  // Number of 2D projections to be analyzed by a single thread. This can be tweaked to see what works best. 32 was the optimal value in the paper by Zinsser and Keck.
+const int VOXELS_PER_THREAD = 8;  // Number of voxels to be computed by s single thread. Can be tweaked to see what works best. 4 was the optimal value in the paper by Zinsser and Keck.
+
+// We have PROJ_PER_KERNEL projections and we need 6 parameters for each projection:
+//   deltaX, deltaY, deltaZ, xyzOrigin, offOrig, offDetec
+// So we need to keep PROJ_PER_KERNEL*6 values in our deltas array FOR EACH CALL to our main kernel
+// (they will be updated in the main loop before each kernel call).
+
+__constant__ Point3D projParamsArrayDevMulti[6*PROJ_PER_KERNEL];  // Dev means it is on device
+
+// We also need a corresponding array on the host side to be filled before each kernel call, then copied to the device (array in constant memory above)
+// Point3D projParamsArrayHost[6*PROJ_PER_KERNEL];   // Host means it is host memory
+
+// Now we also need to store sinAlpha and cosAlpha for each projection (two floats per projection)
+__constant__ float projSinCosArrayDevMulti[5*PROJ_PER_KERNEL];
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// END RB, 10/31/2016: Add constant memory arrays to store parameters for all projections to be analyzed during a single kernel call
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+//______________________________________________________________________________
+//
+//      Function:       kernelPixelBackprojectionFDKMulti
+//
+//      Description:    Main FDK backprojection kernel
+//______________________________________________________________________________
+
+__global__ void kernelPixelBackprojectionFDKMulti(const Geometry geo,
+                                                  float* image,
+                                                  const int currProjSetNumber,
+                                                  const int totalNoOfProjections,
+                                                  const int nChannels,
+                                                  const unsigned long long volumeStride,
+                                                  cudaTextureObject_t tex)
+{
+
+    // Old kernel call signature:
+    // kernelPixelBackprojectionFDKMulti<<<grid,block>>>(geo,dimage,i,deltaX,deltaY,deltaZ,xyzOrigin,offOrig,offDetec,sinalpha,cosalpha);
+    // We just read in most of the params from the constant memory instead of getting them from the param list.
+    // This is because we now have MANY params, since single kernel processes more than one projection!
+    /* __global__ void kernelPixelBackprojectionFDKMulti(const Geometry geo,
+     * float* image,
+     * const int indAlpha,
+     * const Point3D deltaX ,
+     * const Point3D deltaY,
+     * const Point3D deltaZ,
+     * const Point3D xyzOrigin,
+     * const Point3D xyzOffset,
+     * const Point3D uv0Offset,
+     * const float sinalpha,
+     * const float cosalpha){
+     */
+    unsigned long long indY = blockIdx.y * blockDim.y + threadIdx.y;
+    unsigned long long indX = blockIdx.x * blockDim.x + threadIdx.x;
+    // unsigned long startIndZ = blockIdx.z * blockDim.z + threadIdx.z;  // This is only STARTING z index of the column of voxels that the thread will handle
+    unsigned int zBlockCount = (geo.nVoxelZ + VOXELS_PER_THREAD - 1) / VOXELS_PER_THREAD;
+    unsigned int channel = blockIdx.z / zBlockCount;
+    unsigned int localBlockZ = blockIdx.z % zBlockCount;
+    if (channel >= (unsigned int)nChannels)
+        return;
+
+    unsigned long long startIndZ = (unsigned long long)localBlockZ * VOXELS_PER_THREAD + threadIdx.z;  // This is only STARTING z index of the column of voxels that the thread will handle
+    //Make sure we don't go out of bounds
+    if (indX>=geo.nVoxelX || indY>=geo.nVoxelY || startIndZ>=geo.nVoxelZ)
+        return;
+
+    unsigned long long channelOffset = volumeStride * channel;
+    
+    // We'll keep a local auxiliary array of values of a column of voxels that this thread will update
+    float voxelColumn[VOXELS_PER_THREAD];
+    
+    // First we need to copy the curent 3D volume values from the column to our auxiliary array so that we can then
+    // work on them (update them by computing values from multiple projections) locally - avoiding main memory reads/writes
+    
+    unsigned long colIdx;
+#pragma unroll
+    for(colIdx=0; colIdx<VOXELS_PER_THREAD; colIdx++)
+    {
+        unsigned long long indZ = startIndZ + colIdx;
+        // If we are out of bounds, break the loop. The voxelColumn array will be updated partially, but it is OK, because we won't
+        // be trying to copy the out of bounds values back to the 3D volume anyway (bounds checks will be done in the final loop where the updated values go back to the main volume)
+        if(indZ>=geo.nVoxelZ)
+            break;   // break the loop.
+        
+        unsigned long long idx = channelOffset + indZ*(unsigned long long)geo.nVoxelX*(unsigned long long)geo.nVoxelY+indY*(unsigned long long)geo.nVoxelX + indX;
+        voxelColumn[colIdx] = image[idx];   // Read the current volume value that we'll update by computing values from MULTIPLE projections (not just one)
+        // We'll be updating the local (register) variable, avoiding reads/writes from the slow main memory.
+    }  // END copy 3D volume voxels to local array
+    
+    // Now iterate through projections
+#pragma unroll
+    for(unsigned long projNumber=0; projNumber<PROJ_PER_KERNEL; projNumber++)
+    {
+        // Get the current parameters from parameter arrays in constant memory.
+        unsigned long indAlpha = currProjSetNumber*PROJ_PER_KERNEL+projNumber;  // This is the ABSOLUTE projection number in the projection array
+        
+        // Our currImageVal will be updated by hovewer many projections we had left in the "remainder" - that's OK.
+        if(indAlpha>=totalNoOfProjections)
+            break;
+        
+        Point3D deltaX = projParamsArrayDevMulti[6*projNumber];  // 6*projNumber because we have 6 Point3D values per projection
+        Point3D deltaY = projParamsArrayDevMulti[6*projNumber+1];
+        Point3D deltaZ = projParamsArrayDevMulti[6*projNumber+2];
+        Point3D xyzOrigin = projParamsArrayDevMulti[6*projNumber+3];
+        Point3D xyzOffset = projParamsArrayDevMulti[6*projNumber+4];
+        Point3D S = projParamsArrayDevMulti[6*projNumber+5];
+        
+        float sinalpha = projSinCosArrayDevMulti[5*projNumber];     // 2*projNumber because we have 2 float (sin or cos angle) values per projection
+        float cosalpha = projSinCosArrayDevMulti[5*projNumber+1];
+        float COR = projSinCosArrayDevMulti[5*projNumber+2];
+        float DSD = projSinCosArrayDevMulti[5*projNumber+3];
+        float DSO = projSinCosArrayDevMulti[5*projNumber+4];
+        
+        float auxCOR=COR/geo.dDetecU;
+        // Now iterate through Z in our voxel column FOR A GIVEN PROJECTION
+#pragma unroll
+        for(colIdx=0; colIdx<VOXELS_PER_THREAD; colIdx++)
+        {
+            unsigned long long indZ = startIndZ + colIdx;
+            
+            // If we are out of bounds, break the loop. The voxelColumn array will be updated partially, but it is OK, because we won't
+            // be trying to copy the out of bounds values anyway (bounds checks will be done in the final loop where the values go to the main volume)
+            if(indZ>=geo.nVoxelZ)
+                break;   // break the loop.
+            
+            // "XYZ" in the scaled coordinate system of the current point. The image is rotated with the projection angles.
+            Point3D P;
+            P.x=(xyzOrigin.x+indX*deltaX.x+indY*deltaY.x+indZ*deltaZ.x);
+            P.y=(xyzOrigin.y+indX*deltaX.y+indY*deltaY.y+indZ*deltaZ.y)-auxCOR;
+            P.z=(xyzOrigin.z+indX*deltaX.z+indY*deltaY.z+indZ*deltaZ.z);
+            
+            // This is the vector defining the line from the source to the Voxel
+            float vectX,vectY,vectZ;
+            vectX=(P.x -S.x);
+            vectY=(P.y -S.y);
+            vectZ=(P.z -S.z);
+            
+            // Get the coordinates in the detector UV where the mid point of the voxel is projected.
+            float t=__fdividef(DSO-DSD-S.x,vectX);
+            float y,z;
+            y=vectY*t+S.y;
+            z=vectZ*t+S.z;
+            float u,v;
+            u=y+(float)geo.nDetecU*0.5f;
+            v=z+(float)geo.nDetecV*0.5f;
+            
+            float weight;
+            float realx,realy;
+            realx=-(geo.sVoxelX-geo.dVoxelX)*0.5f  +indX*geo.dVoxelX   +xyzOffset.x;
+            realy=-(geo.sVoxelY-geo.dVoxelY)*0.5f  +indY*geo.dVoxelY   +xyzOffset.y+COR;
+            
+            weight=__fdividef(DSO+realy*sinalpha-realx*cosalpha,DSO);
+            
+            weight=__frcp_rd(weight*weight);
+            
+            // Get Value in the computed (U,V) and multiply by the corresponding weight.
+            // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
+            
+#if IS_FOR_MATLAB_TIGRE
+            voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha*(float)nChannels + channel + 0.5f)*weight;
+#else
+            voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha*(float)nChannels + channel + 0.5f)*weight;
+#endif
+        }  // END iterating through column of voxels
+        
+    }  // END iterating through multiple projections
+    
+    // And finally copy the updated local voxelColumn array back to our 3D volume (main memory)
+#pragma unroll
+    for(colIdx=0; colIdx<VOXELS_PER_THREAD; colIdx++)
+    {
+        unsigned long long indZ = startIndZ + colIdx;
+        // If we are out of bounds, break the loop. The voxelColumn array will be updated partially, but it is OK, because we won't
+        // be trying to copy the out of bounds values back to the 3D volume anyway (bounds checks will be done in the final loop where the values go to the main volume)
+        if(indZ>=geo.nVoxelZ)
+            break;   // break the loop.
+        
+        unsigned long long idx = channelOffset + indZ*(unsigned long long)geo.nVoxelX*(unsigned long long)geo.nVoxelY+indY*(unsigned long long)geo.nVoxelX + indX;
+        image[idx] = voxelColumn[colIdx];   // Read the current volume value that we'll update by computing values from MULTIPLE projections (not just one)
+        // We'll be updating the local (register) variable, avoiding reads/writes from the slow main memory.
+        // According to references (Papenhausen), doing = is better than +=, since += requires main memory read followed by a write.
+        // We did all the reads into the local array at the BEGINNING of this kernel. According to Papenhausen, this type of read-write split is
+        // better for avoiding memory congestion.
+    }  // END copy updated voxels from local array to our 3D volume
+    
+}  // END kernelPixelBackprojectionFDKMulti
+
+using namespace tigre_mc_internal;
+
+//______________________________________________________________________________
+//
+//      Function:       voxel_backprojection_multi_channel
+//
+//      Description:    Main host function for FDK backprojection (invokes the kernel)
+//______________________________________________________________________________
+
+int voxel_backprojection_multi_channel(float* projections,
+                                       Geometry geo,
+                                       float* result,
+                                       float const* const alphas,
+                                       int nalpha,
+                                       int nChannels,
+                                       const GpuIds& gpuids)
+{
+    // printf("voxel_backprojection_multi_channel(geo.nDetector = %d, %d)\n", geo.nDetecU, geo.nDetecV);
+    // printf("geo.nVoxel    = %d, %d, %d\n", geo.nVoxelX, geo.nVoxelY, geo.nVoxelZ);
+    
+    // Prepare for MultiGPU
+    int deviceCount = gpuids.GetLength();
+    cudaCheckErrors("Device query fail");
+    if (deviceCount == 0) {
+        mexErrMsgIdAndTxt("Atb:Voxel_backprojection:GPUselect","There are no available device(s) that support CUDA\n");
+    }
+
+    // CODE assumes
+    // 1.-All available devices are usable by this code
+    // 2.-All available devices are equal, they are the same machine (warning thrown)
+    // Check the available devices, and if they are the same
+    if (!gpuids.AreEqualDevices()) {
+        mexWarnMsgIdAndTxt("Atb:Voxel_backprojection:GPUselect","Detected one (or more) different GPUs.\n This code is not smart enough to separate the memory GPU wise if they have different computational times or memory limits.\n First GPU parameters used. If the code errors you might need to change the way GPU selection is performed.");
+    }
+
+    int dev;
+    // Split the CT problem
+    unsigned int split_image;
+    unsigned int split_projections;
+    splitCTbackprojection(gpuids,geo,nalpha,nChannels,&split_image,&split_projections);
+    
+    
+    cudaCheckErrors("Error");
+    //Pagelock memory for synchronous copy.
+    // Lets try to make the host memory pinned:
+    // We laredy queried the GPU and assuemd they are the same, thus should have the same attributes.
+    int isHostRegisterSupported = 0;
+#if CUDART_VERSION >= 9020
+    cudaDeviceGetAttribute(&isHostRegisterSupported,cudaDevAttrHostRegisterSupported,gpuids[0]);
+#endif
+    // empirical testing shows that when the image split is smaller than 1 (also implies the image is not very big), the time to
+    // pin the memory is greater than the lost time in Synchronously launching the memcpys. This is only worth it when the image is too big.
+#ifndef NO_PINNED_MEMORY    
+    if (isHostRegisterSupported & (split_image>1 |deviceCount>1)){
+        cudaHostRegister(result, (size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geo.nVoxelZ*(size_t)nChannels*(size_t)sizeof(float),cudaHostRegisterPortable);
+    }
+    if (isHostRegisterSupported ){
+        cudaHostRegister(projections, (size_t)geo.nDetecU*(size_t)geo.nDetecV*(size_t)nalpha*(size_t)nChannels*(size_t)sizeof(float),cudaHostRegisterPortable);
+    }
+#endif
+    cudaCheckErrors("Error pinning memory");
+    
+    
+    // Create the arrays for the geometry. The main difference is that geo.offZ has been tuned for the
+    // image slices. The rest of the Geometry is the same
+    Geometry* geoArray=(Geometry*)malloc(split_image*deviceCount*sizeof(Geometry));
+    createGeoArray(split_image*deviceCount,geo,geoArray,nalpha);
+    
+    // Now lest allocate all the image memory on the GPU, so we can use it later. If we have made our numbers correctly
+    // in the previous section this should leave enough space for the textures.
+    size_t num_bytes_img = (size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geoArray[0].nVoxelZ*(size_t)nChannels* sizeof(float);
+    float** dimage=(float**)malloc(deviceCount*sizeof(float*));
+    for (dev = 0; dev < deviceCount; dev++){
+        cudaSetDevice(gpuids[dev]);
+        cudaMalloc((void**)&dimage[dev], num_bytes_img);
+        cudaCheckErrors("cudaMalloc fail");
+    }
+    
+    //If it is the first time, lets make sure our image is zeroed.
+    int nStreamDevice=2;
+    int nStreams=deviceCount*nStreamDevice;
+    cudaStream_t* stream=(cudaStream_t*)malloc(nStreams*sizeof(cudaStream_t));;
+    
+    for (dev = 0; dev < deviceCount; dev++){
+        cudaSetDevice(gpuids[dev]);
+        for (int i = 0; i < nStreamDevice; ++i){
+            cudaStreamCreate(&stream[i+dev*nStreamDevice]);
+            
+        }
+    }
+    
+
+     
+    
+    // Kernel auxiliary variables
+    Point3D* projParamsArrayHost;
+    cudaMallocHost((void**)&projParamsArrayHost,6*PROJ_PER_KERNEL*sizeof(Point3D));
+    float* projSinCosArrayHost;
+    cudaMallocHost((void**)&projSinCosArrayHost,5*PROJ_PER_KERNEL*sizeof(float));
+    
+    
+    // Texture object variables
+    cudaTextureObject_t *texProj;
+    cudaArray **d_cuArrTex;
+    texProj =(cudaTextureObject_t*)malloc(deviceCount*2*sizeof(cudaTextureObject_t));
+    d_cuArrTex =(cudaArray**)malloc(deviceCount*2*sizeof(cudaArray*));
+    
+    // Auxiliary Host page-locked memory for fast and asycnornous memcpy.
+
+    // Start with the main loop. The Projection data needs to be allocated and dealocated in the main loop
+    // as due to the nature of cudaArrays, we can not reuse them. This should not be a problem for the fast execution
+    // of the code, as repeated allocation and deallocation only happens when the projection data is very very big,
+    // and therefore allcoation time should be negligible, fluctuation of other computations should mask the time.
+    unsigned long long proj_linear_idx_start;
+    unsigned int proj_split_overlap_number;
+    unsigned int current_proj_split_size,current_proj_overlap_split_size;
+    size_t img_linear_idx_start;
+    float** partial_projection;
+    size_t* proj_split_size;
+    
+    
+    
+    for(unsigned int img_slice=0;img_slice<split_image;img_slice++){
+        // Initialize the memory if its the first time.
+        for (dev = 0; dev < deviceCount; dev++){
+            cudaSetDevice(gpuids[dev]);
+            cudaMemset(dimage[dev],0,num_bytes_img);
+            cudaCheckErrors("memset fail");
+        }
+        
+        for( unsigned int proj=0;proj<split_projections;proj++){
+            
+            
+            // What is the size of the current chunk of proejctions we need in?
+            current_proj_split_size=(nalpha+split_projections-1)/split_projections;
+            // if its the last one its probably less
+            current_proj_split_size=((proj+1)*current_proj_split_size<nalpha)?  current_proj_split_size:  nalpha-current_proj_split_size*proj;
+            
+            // We are going to split it in the same amount of kernels we need to execute.
+            proj_split_overlap_number=(current_proj_split_size+PROJ_PER_KERNEL-1)/PROJ_PER_KERNEL;
+            
+            // Create pointer to pointers of projections and precompute their location and size.
+            if(!proj && !img_slice){
+                partial_projection=(float**)malloc(proj_split_overlap_number*sizeof(float*));
+                proj_split_size=(size_t*)malloc(proj_split_overlap_number*sizeof(size_t));
+            }
+            for(unsigned int proj_block_split=0; proj_block_split<proj_split_overlap_number;proj_block_split++){
+                // Crop the last one, as its likely its not completely divisible.
+                // now lets split this for simultanoeus memcopy and compute.
+                // We want to make sure that if we can, we run PROJ_PER_KERNEL projections, to maximize kernel acceleration
+                // current_proj_overlap_split_size units = angles
+                current_proj_overlap_split_size=max((current_proj_split_size+proj_split_overlap_number-1)/proj_split_overlap_number,PROJ_PER_KERNEL);
+                current_proj_overlap_split_size=(proj_block_split<proj_split_overlap_number-1)?current_proj_overlap_split_size:current_proj_split_size-(proj_split_overlap_number-1)*current_proj_overlap_split_size;
+                //Get the linear index where the current memory chunk starts.
+                
+                unsigned long long det_pixels = (unsigned long long)geo.nDetecU*(unsigned long long)geo.nDetecV*(unsigned long long)nChannels;
+                proj_linear_idx_start=(unsigned long long)((nalpha+split_projections-1)/split_projections)*(unsigned long long)proj*det_pixels;
+                proj_linear_idx_start+=proj_block_split*max((current_proj_split_size+proj_split_overlap_number-1)/proj_split_overlap_number,PROJ_PER_KERNEL)*det_pixels;
+                //Store result
+                proj_split_size[proj_block_split]=current_proj_overlap_split_size;
+                partial_projection[proj_block_split]=&projections[proj_linear_idx_start];
+                
+            }                
+            for(unsigned int proj_block_split=0; proj_block_split<proj_split_overlap_number;proj_block_split++){
+
+                // Now get the projections on memory
+
+                CreateTextureMulti(gpuids,
+                        partial_projection[proj_block_split],geo,
+                        &d_cuArrTex[(proj_block_split%2)*deviceCount],
+                        proj_split_size[proj_block_split],
+                        nChannels,
+                        &texProj   [(proj_block_split%2)*deviceCount],
+                        stream, nStreamDevice,
+                        (proj_block_split<2)&!proj&!img_slice);// Only allocate if its the first 2 calls
+                
+                for (dev = 0; dev < deviceCount; dev++){
+                    cudaSetDevice(gpuids[dev]);
+                    cudaStreamSynchronize(stream[dev*nStreamDevice+1]);
+                 }
+                               
+                // Pin the next chunk of projection data, unpin the current one.
+                for (dev = 0; dev < deviceCount; dev++){
+                    //Safety:
+                    // Depends on the amount of GPUs, the case where a image slice is zero hight can happen.
+                    // Just break the loop if we reached that point
+                    if(geoArray[img_slice*deviceCount+dev].nVoxelZ==0)
+                        break;
+                    
+                    cudaSetDevice(gpuids[dev]);
+                    
+                    
+                    
+                    int divx,divy,divz;
+                    // RB: Use the optimal (in their tests) block size from paper by Zinsser and Keck (16 in x and 32 in y).
+                    // I tried different sizes and shapes of blocks (tiles), but it does not appear to significantly affect throughput, so
+                    // let's stick with the values from Zinsser and Keck.
+                    divx=16;
+                    divy=32;
+                    divz=VOXELS_PER_THREAD;      // We now only have 32 x 16 threads per block (flat tile, see below), BUT each thread works on a Z column of VOXELS_PER_THREAD voxels, so we effectively need fewer blocks!
+                    
+                    
+                    dim3 grid((geo.nVoxelX+divx-1)/divx,
+                            (geo.nVoxelY+divy-1)/divy,
+                            ((geoArray[img_slice*deviceCount+dev].nVoxelZ+divz-1)/divz)*nChannels);
+                    
+                    dim3 block(divx,divy,1);    // Note that we have 1 in the Z size, not divz, since each thread works on a vertical set of VOXELS_PER_THREAD voxels (so we only need a "flat" tile of threads, with depth of 1)
+                    //////////////////////////////////////////////////////////////////////////////////////
+                    // Main reconstruction loop: go through projections (rotation angles) and backproject
+                    //////////////////////////////////////////////////////////////////////////////////////
+                    
+                    // Since we'll have multiple projections processed by a SINGLE kernel call, compute how many
+                    // kernel calls we'll need altogether.
+                    unsigned int noOfKernelCalls = (proj_split_size[proj_block_split]+PROJ_PER_KERNEL-1)/PROJ_PER_KERNEL;  // We'll take care of bounds checking inside the loop if nalpha is not divisible by PROJ_PER_KERNEL
+                    for (unsigned int i=0; i<noOfKernelCalls; i++){
+                        
+                        // Now we need to generate and copy all data for PROJ_PER_KERNEL projections to constant memory so that our kernel can use it
+                        unsigned int j;
+                        for(j=0; j<PROJ_PER_KERNEL; j++){
+                            
+                            unsigned int currProjNumber_slice=i*PROJ_PER_KERNEL+j;
+                            unsigned int currProjNumber_global=i*PROJ_PER_KERNEL+j                                                                          // index within kernel
+                                                               +proj*(nalpha+split_projections-1)/split_projections                                          // index of the global projection split
+                                                               +proj_block_split*max(current_proj_split_size/proj_split_overlap_number,PROJ_PER_KERNEL); // indexof overlap current split
+                            
+                            if(currProjNumber_slice>=proj_split_size[proj_block_split])
+                                break;  // Exit the loop. Even when we leave the param arrays only partially filled, this is OK, since the kernel will check bounds anyway.
+                            if(currProjNumber_global>=nalpha)
+                                break;  // Exit the loop. Even when we leave the param arrays only partially filled, this is OK, since the kernel will check bounds anyway.
+                            
+                            Point3D deltaX,deltaY,deltaZ,xyzOrigin, offOrig, /*offDetec,*/source;
+                            float sinalpha,cosalpha;
+                            
+                            geoArray[img_slice*deviceCount+dev].alpha=-alphas[currProjNumber_global*3];//we got 3 angles now.
+                            geoArray[img_slice*deviceCount+dev].theta=-alphas[currProjNumber_global*3+1];
+                            geoArray[img_slice*deviceCount+dev].psi  =-alphas[currProjNumber_global*3+2];
+                            
+//                             mexPrintf("%u %f \n",i,geoArray[img_slice*deviceCount+dev].alpha);
+//                             mexPrintf("%u \n",currProjNumber_global);
+                            
+                            sinalpha=sin(geoArray[img_slice*deviceCount+dev].alpha);
+                            cosalpha=cos(geoArray[img_slice*deviceCount+dev].alpha);
+                            
+                            projSinCosArrayHost[5*j]=sinalpha;  // 2*j because we have 2 float (sin or cos angle) values per projection
+                            projSinCosArrayHost[5*j+1]=cosalpha;
+                            projSinCosArrayHost[5*j+2]=geo.COR[currProjNumber_global];
+                            projSinCosArrayHost[5*j+3]=geo.DSD[currProjNumber_global];
+                            projSinCosArrayHost[5*j+4]=geo.DSO[currProjNumber_global];
+                            
+                            computeDeltasCube(geoArray[img_slice*deviceCount+dev],currProjNumber_global,&xyzOrigin,&deltaX,&deltaY,&deltaZ,&source);
+                            
+                            offOrig.x=geo.offOrigX[currProjNumber_global];
+                            offOrig.y=geo.offOrigY[currProjNumber_global];
+                            offOrig.z=geoArray[img_slice*deviceCount+dev].offOrigZ[currProjNumber_global];
+                            
+                            projParamsArrayHost[6*j]=deltaX;		// 6*j because we have 6 Point3D values per projection
+                            projParamsArrayHost[6*j+1]=deltaY;
+                            projParamsArrayHost[6*j+2]=deltaZ;
+                            projParamsArrayHost[6*j+3]=xyzOrigin;
+                            projParamsArrayHost[6*j+4]=offOrig;
+                            projParamsArrayHost[6*j+5]=source;
+                        }   // END for (preparing params for kernel call)
+                        
+                        // Copy the prepared parameter arrays to constant memory to make it available for the kernel
+                        cudaMemcpyToSymbolAsync(projSinCosArrayDevMulti, projSinCosArrayHost, sizeof(float)*5*PROJ_PER_KERNEL,0,cudaMemcpyHostToDevice,stream[dev*nStreamDevice]);
+                        cudaMemcpyToSymbolAsync(projParamsArrayDevMulti, projParamsArrayHost, sizeof(Point3D)*6*PROJ_PER_KERNEL,0,cudaMemcpyHostToDevice,stream[dev*nStreamDevice]);
+                        cudaStreamSynchronize(stream[dev*nStreamDevice]);
+                        
+                        unsigned long long localVolumeStride = (unsigned long long)geoArray[img_slice*deviceCount+dev].nVoxelX*
+                                                                  (unsigned long long)geoArray[img_slice*deviceCount+dev].nVoxelY*
+                                                                  (unsigned long long)geoArray[img_slice*deviceCount+dev].nVoxelZ;
+                        kernelPixelBackprojectionFDKMulti<<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],
+                                                                                                      dimage[dev],
+                                                                                                      i,
+                                                                                                      static_cast<int>(proj_split_size[proj_block_split]),
+                                                                                                      nChannels,
+                                                                                                      localVolumeStride,
+                                                                                                      texProj[(proj_block_split%2)*deviceCount+dev]);
+                    }  // END for
+                    //////////////////////////////////////////////////////////////////////////////////////
+                    // END RB code, Main reconstruction loop: go through projections (rotation angles) and backproject
+                    //////////////////////////////////////////////////////////////////////////////////////
+                }// END for deviceCount
+            } // END sub-split of current projection chunk
+            
+            for (dev = 0; dev < deviceCount; dev++){
+                cudaSetDevice(gpuids[dev]);
+                cudaDeviceSynchronize();
+            }
+            
+        } // END projection splits
+        
+       
+        // Now we need to take the image out of the GPU
+        for (dev = 0; dev < deviceCount; dev++){
+            cudaSetDevice(gpuids[dev]);
+            // We do not need to sycnronize because the array dealocators already do.
+            size_t slice_voxels=(size_t)geoArray[img_slice*deviceCount+dev].nVoxelX*(size_t)geoArray[img_slice*deviceCount+dev].nVoxelY*(size_t)geoArray[img_slice*deviceCount+dev].nVoxelZ;
+            size_t per_channel_bytes=slice_voxels*sizeof(float);
+            img_linear_idx_start=(size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geoArray[0].nVoxelZ*(size_t)(img_slice*deviceCount+dev);
+            for(int channel=0; channel<nChannels; ++channel){
+                size_t host_offset=(size_t)channel*(size_t)geo.nVoxelX*(size_t)geo.nVoxelY*(size_t)geo.nVoxelZ+img_linear_idx_start;
+                size_t device_offset=(size_t)channel*slice_voxels;
+                cudaMemcpyAsync(&result[host_offset], &dimage[dev][device_offset], per_channel_bytes, cudaMemcpyDeviceToHost,stream[dev*nStreamDevice+1]);
+            }
+        }
+        for (dev = 0; dev < deviceCount; dev++){
+            cudaSetDevice(gpuids[dev]);
+            cudaDeviceSynchronize();
+            cudaCheckErrors("Main loop fail");
+        }
+        
+    } // end image splits
+
+    ///////// Cleaning:
+    
+    
+    bool two_buffers_used=((((nalpha+split_projections-1)/split_projections)+PROJ_PER_KERNEL-1)/PROJ_PER_KERNEL)>1;
+    for(unsigned int i=0; i<2;i++){ // 2 buffers (if needed, maybe only 1)
+        if (!two_buffers_used && i==1)
+            break;
+        for (dev = 0; dev < deviceCount; dev++){
+            cudaSetDevice(gpuids[dev]);
+            cudaDestroyTextureObject(texProj[i*deviceCount+dev]);
+            cudaFreeArray(d_cuArrTex[i*deviceCount+dev]);
+        }
+    }
+    cudaCheckErrors("cudadestroy textures result fail");
+    
+    for (dev = 0; dev < deviceCount; dev++){
+        cudaSetDevice(gpuids[dev]);
+        cudaFree(dimage[dev]);
+    }
+    cudaFreeHost(projSinCosArrayHost);
+    cudaFreeHost(projParamsArrayHost);
+    free(partial_projection);
+    free(proj_split_size);
+    
+    freeGeoArray(split_image*deviceCount,geoArray);
+#ifndef NO_PINNED_MEMORY        
+    if (isHostRegisterSupported & (split_image>1 |deviceCount>1)){
+        cudaHostUnregister(result);
+    }
+    if (isHostRegisterSupported){
+        cudaHostUnregister(projections);
+    }
+#endif
+    
+    for (int i = 0; i < nStreams; ++i)
+        cudaStreamDestroy(stream[i]);
+    
+    cudaCheckErrors("cudaFree fail");
+    
+    //cudaDeviceReset(); // For the Nvidia Visual Profiler
+    return 0;
+    
+}  // END voxel_backprojection_multi_channel
+//
+
+void splitCTbackprojection(const GpuIds& gpuids, Geometry geo,int nalpha, int nChannels, unsigned int* split_image, unsigned int * split_projections){
+    
+    
+    // We don't know if the devices are being used. lets check that. and only use the amount of memory we need.
+    
+    size_t mem_GPU_global;
+    checkFreeMemory(gpuids, &mem_GPU_global);
+
+    const int deviceCount = gpuids.GetLength();
+        
+    // Compute how much memory each of the relevant memory pieces need
+    size_t mem_image=       (unsigned long long)geo.nVoxelX*(unsigned long long)geo.nVoxelY*(unsigned long long)geo.nVoxelZ*(unsigned long long)nChannels*sizeof(float);
+    size_t mem_proj=        (unsigned long long)geo.nDetecU*(unsigned long long)geo.nDetecV*(unsigned long long)nChannels*sizeof(float);
+    
+    
+    
+    
+    // Does everything fit in the GPU?
+    
+    if(mem_image/deviceCount+mem_proj*PROJ_PER_KERNEL*2<mem_GPU_global){
+        // We only need to split if we have extra GPUs
+        *split_image=1;
+        *split_projections=1;
+    }
+    // We know we need to split, but:
+    // Does all the image fit in the GPU, with some slack for a stack of projections??
+    else
+    {
+        // As we can overlap memcpys from H2D of the projections, we should then minimize the amount of image splits.
+        // Lets assume to start with that we only need 1 stack of PROJ_PER_KERNEL projections. The rest is for the image.
+        size_t mem_free=mem_GPU_global-2*mem_proj*PROJ_PER_KERNEL;
+        
+        *split_image=(mem_image/deviceCount+mem_free-1)/mem_free;
+        // Now knowing how many splits we have for images, we can recompute how many slices of projections actually
+        // fit on the GPU. Must be more than 0 obviously.
+        
+        mem_free=mem_GPU_global-(mem_image/deviceCount)/(*split_image); // NOTE: There is some rounding error, but its in the order of bytes, and we have 5% of GPU free jsut in case. We are safe
+        
+        
+        *split_projections=(mem_proj*PROJ_PER_KERNEL*2+mem_free-1)/mem_free;
+        
+    }
+}
+
+
+void CreateTextureMulti(const GpuIds& gpuids,
+                        float* projectiondata,
+                        Geometry geo,
+                        cudaArray** d_cuArrTex,
+                        unsigned int nangles,
+                        unsigned int nChannels,
+                        cudaTextureObject_t *texImage,
+                        cudaStream_t* stream,
+                        int nStreamDevice,
+                        bool allocate){
+    //size_t size_image=geo.nVoxelX*geo.nVoxelY*geo.nVoxelZ;
+#if IS_FOR_MATLAB_TIGRE
+    const cudaExtent extent =make_cudaExtent(geo.nDetecV, geo.nDetecU, nangles*nChannels);
+#else
+    const cudaExtent extent =make_cudaExtent(geo.nDetecU, geo.nDetecV, nangles*nChannels);
+#endif
+    const unsigned int num_devices = gpuids.GetLength();
+    if (allocate){
+        for (unsigned int dev = 0; dev < num_devices; dev++){
+            cudaSetDevice(gpuids[dev]);
+            
+            //cudaArray Descriptor
+            cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<float>();
+            //cuda Array
+            cudaMalloc3DArray(&d_cuArrTex[dev], &channelDesc, extent);
+            
+        }
+    }
+    for (unsigned int dev = 0; dev < num_devices; dev++){
+        cudaSetDevice(gpuids[dev]);
+        cudaMemcpy3DParms copyParams = {0};
+        //Array creation
+        copyParams.srcPtr   = make_cudaPitchedPtr((void *)projectiondata, extent.width*sizeof(float), extent.width, extent.height);
+        copyParams.dstArray = d_cuArrTex[dev];
+        copyParams.extent   = extent;
+        copyParams.kind     = cudaMemcpyHostToDevice;
+        cudaMemcpy3DAsync(&copyParams,stream[dev*nStreamDevice+1]);
+    }
+
+    //Array creation End
+    for (unsigned int dev = 0; dev < num_devices; dev++){
+        cudaSetDevice(gpuids[dev]);
+        cudaResourceDesc    texRes;
+        memset(&texRes, 0, sizeof(cudaResourceDesc));
+        texRes.resType = cudaResourceTypeArray;
+        texRes.res.array.array  = d_cuArrTex[dev];
+        cudaTextureDesc     texDescr;
+        memset(&texDescr, 0, sizeof(cudaTextureDesc));
+        texDescr.normalizedCoords = false;
+        texDescr.filterMode = cudaFilterModeLinear;
+        texDescr.addressMode[0] = cudaAddressModeBorder;
+        texDescr.addressMode[1] = cudaAddressModeBorder;
+        texDescr.addressMode[2] = cudaAddressModeBorder;
+        texDescr.readMode = cudaReadModeElementType;
+        cudaCreateTextureObject(&texImage[dev], &texRes, &texDescr, NULL);
+    }
+}
+
+//______________________________________________________________________________
+//
+//      Function:       createGeoArray
+//
+//      Description:    This code generates the geometries needed to split the image properly in
+//                      cases where the entire image does not fit in the memory of the GPU
+//______________________________________________________________________________
+
+void createGeoArray(unsigned int image_splits, Geometry geo,Geometry* geoArray, unsigned int nangles){
+    
+    
+    unsigned int  splitsize=(geo.nVoxelZ+image_splits-1)/image_splits;
+    
+    for(unsigned int sp=0;sp<image_splits;sp++){
+        geoArray[sp]=geo;
+        // All of them are splitsize, but the last one, possible
+        geoArray[sp].nVoxelZ=((sp+1)*splitsize<geo.nVoxelZ)?  splitsize:  max(geo.nVoxelZ-splitsize*sp,0);
+        geoArray[sp].sVoxelZ= geoArray[sp].nVoxelZ* geoArray[sp].dVoxelZ;
+        
+        // We need to redefine the offsets, as now each subimage is not aligned in the origin.
+        geoArray[sp].offOrigZ=(float *)malloc(nangles*sizeof(float));
+        for (unsigned int i=0;i<nangles;i++){
+            geoArray[sp].offOrigZ[i]=geo.offOrigZ[i]-geo.sVoxelZ/2+sp*geoArray[0].sVoxelZ+geoArray[sp].sVoxelZ/2;
+        }
+    }
+    
+}
+//______________________________________________________________________________
+//
+//      Function:       freeGeoArray
+//
+//      Description:    Frees the memory from the geometry array for multiGPU.
+//______________________________________________________________________________
+void freeGeoArray(unsigned int splits,Geometry* geoArray){
+    for(unsigned int sp=0;sp<splits;sp++){
+        free(geoArray[sp].offOrigZ);
+    }
+    free(geoArray);
+}
+
+
+//______________________________________________________________________________
+//
+//      double precision functions for rotating Point3Ddouble coordinates
+//______________________________________________________________________________
+
+void eulerZYZT(Geometry geo, Point3Ddouble* point){
+    
+    Point3Ddouble auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+
+    // calculate sin and cos of 3 angles (used multiple times)
+    double sin_alpha, cos_alpha, sin_theta, cos_theta, sin_psi, cos_psi;
+    sin_alpha = sin((double)geo.alpha);
+    cos_alpha = cos((double)geo.alpha);
+    sin_theta = sin((double)geo.theta);
+    cos_theta = cos((double)geo.theta);
+    sin_psi = sin((double)geo.psi);
+    cos_psi = cos((double)geo.psi);
+    
+    point->x = auxPoint.x*(cos_psi*cos_theta*cos_alpha-sin_psi*sin_alpha)
+    +auxPoint.y*(-cos_psi*cos_theta*sin_alpha-sin_psi*cos_alpha)
+    +auxPoint.z*cos_psi*sin_theta;
+    point->y = auxPoint.x*(sin_psi*cos_theta*cos_alpha+cos_psi*sin_alpha)
+    +auxPoint.y*(-sin_psi*cos_theta*sin_alpha+cos_psi*cos_alpha)
+    +auxPoint.z*sin_psi*sin_theta;
+    point->z =-auxPoint.x*sin_theta*cos_alpha
+    +auxPoint.y*sin_theta*sin_alpha
+    +auxPoint.z*cos_theta;
+}
+
+void rollPitchYawT(Geometry geo,int i, Point3Ddouble* point){
+
+    Point3Ddouble auxPoint;
+    auxPoint.x=point->x;
+    auxPoint.y=point->y;
+    auxPoint.z=point->z;
+
+    // calculate sin and cos of 3 angles (used multiple times)
+    double sin_dRoll, cos_dRoll, sin_dPitch, cos_dPitch, sin_dYaw, cos_dYaw;
+    sin_dRoll = sin((double)geo.dRoll[i]);
+    cos_dRoll = cos((double)geo.dRoll[i]);
+    sin_dPitch = sin((double)geo.dPitch[i]);
+    cos_dPitch = cos((double)geo.dPitch[i]);
+    sin_dYaw = sin((double)geo.dYaw[i]);
+    cos_dYaw = cos((double)geo.dYaw[i]);
+    
+    point->x=cos_dRoll*cos_dPitch*auxPoint.x
+            +sin_dRoll*cos_dPitch*auxPoint.y
+            -sin_dPitch*auxPoint.z;
+    
+    point->y=(cos_dRoll*sin_dPitch*sin_dYaw - sin_dRoll*cos_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*sin_dYaw + cos_dRoll*cos_dYaw)*auxPoint.y
+            +cos_dPitch*sin_dYaw*auxPoint.z;
+    
+    point->z=(cos_dRoll*sin_dPitch*cos_dYaw + sin_dRoll*sin_dYaw)*auxPoint.x
+            +(sin_dRoll*sin_dPitch*cos_dYaw - cos_dRoll*sin_dYaw)*auxPoint.y
+            +cos_dPitch*cos_dYaw*auxPoint.z;
+}
+
+//______________________________________________________________________________
+//
+//      Function:       computeDeltasCube
+//
+//      Description:    Computes relative increments for each projection (volume rotation).
+//						Increments get passed to the backprojection kernel.
+//______________________________________________________________________________
+
+void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S)
+{
+    
+    // initialize points with double precision
+    Point3Ddouble P, Px,Py,Pz;
+
+    // Get coords of Img(0,0,0)
+    P.x=-(geo.sVoxelX/2-geo.dVoxelX/2)+geo.offOrigX[i];
+    P.y=-(geo.sVoxelY/2-geo.dVoxelY/2)+geo.offOrigY[i];
+    P.z=-(geo.sVoxelZ/2-geo.dVoxelZ/2)+geo.offOrigZ[i];
+    
+    // Get coords from next voxel in each direction
+    Px.x=P.x+geo.dVoxelX;       Py.x=P.x;                Pz.x=P.x;
+    Px.y=P.y;                   Py.y=P.y+geo.dVoxelY;    Pz.y=P.y;
+    Px.z=P.z;                   Py.z=P.z;                Pz.z=P.z+geo.dVoxelZ;
+    
+    // Rotate image around X axis (this is equivalent of rotating the source and detector) RZ RY RZ
+    eulerZYZT(geo,&P);
+    eulerZYZT(geo,&Px);
+    eulerZYZT(geo,&Py);
+    eulerZYZT(geo,&Pz);
+    
+    //detector offset
+    P.z =P.z-geo.offDetecV[i];            P.y =P.y-geo.offDetecU[i];
+    Px.z =Px.z-geo.offDetecV[i];          Px.y =Px.y-geo.offDetecU[i];
+    Py.z =Py.z-geo.offDetecV[i];          Py.y =Py.y-geo.offDetecU[i];
+    Pz.z =Pz.z-geo.offDetecV[i];          Pz.y =Pz.y-geo.offDetecU[i];
+    
+    //Detector Roll pitch Yaw
+    //
+    // first, we need to offset everything so (0,0,0) is the center of the detector
+    // Only X is required for that
+    P.x=P.x+(geo.DSD[i]-geo.DSO[i]);
+    Px.x=Px.x+(geo.DSD[i]-geo.DSO[i]);
+    Py.x=Py.x+(geo.DSD[i]-geo.DSO[i]);
+    Pz.x=Pz.x+(geo.DSD[i]-geo.DSO[i]);
+    rollPitchYawT(geo,i,&P);
+    rollPitchYawT(geo,i,&Px);
+    rollPitchYawT(geo,i,&Py);
+    rollPitchYawT(geo,i,&Pz);
+    
+    P.x=P.x-(geo.DSD[i]-geo.DSO[i]);
+    Px.x=Px.x-(geo.DSD[i]-geo.DSO[i]);
+    Py.x=Py.x-(geo.DSD[i]-geo.DSO[i]);
+    Pz.x=Pz.x-(geo.DSD[i]-geo.DSO[i]);
+    //Done for P, now source
+    Point3Ddouble source;
+    source.x=geo.DSD[i]; //already offseted for rotation
+    source.y=-geo.offDetecU[i];
+    source.z=-geo.offDetecV[i];
+    rollPitchYawT(geo,i,&source);
+    
+    source.x=source.x-(geo.DSD[i]-geo.DSO[i]);//   source.y=source.y-auxOff.y;    source.z=source.z-auxOff.z;
+    
+//       mexPrintf("%f,%f,%f\n",source.x,source.y,source.z);
+    // Scale coords so detector pixels are 1x1
+    
+    P.z =P.z /geo.dDetecV;                          P.y =P.y/geo.dDetecU;
+    Px.z=Px.z/geo.dDetecV;                          Px.y=Px.y/geo.dDetecU;
+    Py.z=Py.z/geo.dDetecV;                          Py.y=Py.y/geo.dDetecU;
+    Pz.z=Pz.z/geo.dDetecV;                          Pz.y=Pz.y/geo.dDetecU;
+    
+    source.z=source.z/geo.dDetecV;                  source.y=source.y/geo.dDetecU;
+    
+    // get deltas of the changes in voxels
+    deltaX->x=Px.x-P.x;   deltaX->y=Px.y-P.y;    deltaX->z=Px.z-P.z;
+    deltaY->x=Py.x-P.x;   deltaY->y=Py.y-P.y;    deltaY->z=Py.z-P.z;
+    deltaZ->x=Pz.x-P.x;   deltaZ->y=Pz.y-P.y;    deltaZ->z=Pz.z-P.z;
+    
+    // cast the results from the double precision calculations back to float
+    *xyzorigin=P.to_float();
+    *S=source.to_float();
+}
+
+void checkFreeMemory(const GpuIds& gpuids,size_t *mem_GPU_global){
+    size_t memfree;
+    size_t memtotal;
+    const int deviceCount = gpuids.GetLength();
+    
+    for (int dev = 0; dev < deviceCount; dev++){
+        cudaSetDevice(gpuids[dev]);
+        cudaMemGetInfo(&memfree,&memtotal);
+        if(dev==0) *mem_GPU_global=memfree;
+        if(memfree<memtotal/2){
+            mexErrMsgIdAndTxt("voxel_backprojection:Atb:GPU","One (or more) of your GPUs is being heavily used by another program (possibly graphics-based).\n Free the GPU to run TIGRE\n");
+        }
+        cudaCheckErrors("Check mem error");
+        
+        *mem_GPU_global=(memfree<*mem_GPU_global)?memfree:*mem_GPU_global;
+    }
+    *mem_GPU_global=(size_t)((double)*mem_GPU_global*0.95);
+    
+    //*mem_GPU_global= insert your known number here, in bytes.
+}
+
+}  // namespace tigre_mc_internal
+

--- a/CustomOperators/multi_channel_backprojection/multi_channel_backprojection.hpp
+++ b/CustomOperators/multi_channel_backprojection/multi_channel_backprojection.hpp
@@ -1,0 +1,24 @@
+/*-------------------------------------------------------------------------
+ *
+ * Multi-channel CUDA backprojection interface for TIGRE.
+ *
+ * Based on the original single-channel implementation by Ander Biguri and
+ * contributors.
+ * ---------------------------------------------------------------------------
+ */
+
+#ifndef MULTI_CHANNEL_BACKPROJECTION_HPP
+#define MULTI_CHANNEL_BACKPROJECTION_HPP
+
+#include "types_TIGRE.hpp"
+#include "GpuIds.hpp"
+
+int voxel_backprojection_multi_channel(float* projections,
+                                       Geometry geo,
+                                       float* result,
+                                       float const* const alphas,
+                                       int nalpha,
+                                       int nChannels,
+                                       const GpuIds& gpuids);
+
+#endif  // MULTI_CHANNEL_BACKPROJECTION_HPP

--- a/Python/tigre/__init__.py
+++ b/Python/tigre/__init__.py
@@ -23,6 +23,7 @@ from .utilities.geometry_default import ConeGeometryDefault as geometry_default
 from .utilities.geometry_default import FanGeometryDefault as fan_geometry_default
 from .utilities.Ax import Ax
 from .utilities.Atb import Atb
+from .utilities.Atb_multi_channel import Atb_multi_channel
 from .utilities.visualization.plotproj import plotproj, plotProj, plotSinogram
 from .utilities.visualization.plotimg import plotimg, plotImg
 from .utilities.visualization.plot_geometry import plot_geometry

--- a/Python/tigre/utilities/Atb_multi_channel.py
+++ b/Python/tigre/utilities/Atb_multi_channel.py
@@ -1,0 +1,108 @@
+import copy
+from typing import Literal, Optional
+
+import numpy as np
+
+from _Atb_multi_channel import _Atb_multi_channel_ext
+from .gpu import GpuIds
+
+
+LayoutHint = Literal["angles_channels", "channels_angles"]
+OutputOrder = Literal["channels_xyz", "channels_zyx"]
+
+
+def _normalise_projections(projections: np.ndarray, n_angles: int, layout: LayoutHint) -> np.ndarray:
+    if projections.ndim != 4:
+        raise ValueError(
+            "Expected a 4D array with axes (angles, channels, detV, detU) or (channels, angles, detV, detU)."
+        )
+
+    if layout == "angles_channels":
+        if projections.shape[0] != n_angles:
+            raise ValueError(
+                f"Projection stack reports layout 'angles_channels' but first dimension ({projections.shape[0]}) "
+                f"does not match the number of angles ({n_angles})."
+            )
+        return projections
+    if layout == "channels_angles":
+        if projections.shape[1] != n_angles:
+            raise ValueError(
+                f"Projection stack reports layout 'channels_angles' but second dimension ({projections.shape[1]}) "
+                f"does not match the number of angles ({n_angles})."
+            )
+        return np.transpose(projections, (1, 0, 2, 3))
+
+    raise ValueError(f"Unsupported layout hint: {layout}")
+
+
+def Atb_multi_channel(
+    projections: np.ndarray,
+    geo,
+    angles: np.ndarray,
+    *,
+    layout: LayoutHint = "angles_channels",
+    output_order: OutputOrder = "channels_xyz",
+    vflip: bool = False,
+    gpuids: Optional[GpuIds] = None,
+) -> np.ndarray:
+    """Multi-channel wrapper around TIGRE's backprojector.
+
+    Parameters
+    ----------
+    projections:
+        Projection tensor with layout specified by ``layout`` and dtype ``float32``.
+    geo:
+        TIGRE geometry instance.
+    angles:
+        Acquisition angles in radians with shape ``(n_angles,)`` or ``(n_angles, 1|2)``.
+    layout:
+        ``"angles_channels"`` expects data laid out as ``(n_angles, n_channels, nDetecV, nDetecU)``.
+        ``"channels_angles"`` expects ``(n_channels, n_angles, nDetecV, nDetecU)`` and will transpose it.
+    output_order:
+        ``"channels_xyz"`` returns ``(n_channels, nVoxelX, nVoxelY, nVoxelZ)``. ``"channels_zyx"`` keeps the
+        native TIGRE layout ``(n_channels, nVoxelZ, nVoxelY, nVoxelX)``.
+    vflip:
+        If ``True`` the detector V dimension will be flipped back before calling the CUDA kernel. This mirrors
+        the manual ``[::-1]`` flip often used during forward projection.
+    gpuids:
+        Optional :class:`~tigre.utilities.gpu.GpuIds` instance. A fresh instance is created when omitted.
+    """
+    if projections.dtype != np.float32:
+        raise TypeError("Input data should be float32, not " + str(projections.dtype))
+    if not np.isrealobj(projections):
+        raise ValueError("Complex types not compatible for back projection.")
+
+    geox = copy.deepcopy(geo)
+    geox.check_geo(angles)
+    geox.cast_to_single()
+
+    n_angles = geox.angles.shape[0]
+
+    layout_hint: LayoutHint = layout
+    projections = _normalise_projections(np.asarray(projections), n_angles, layout_hint)
+
+    if projections.shape[2] != geox.nDetector[0] or projections.shape[3] != geox.nDetector[1]:
+        raise ValueError(
+            "Expected detector dimensions ({} , {}) but received {}.".format(
+                geox.nDetector[0], geox.nDetector[1], projections.shape[2:4]
+            )
+        )
+
+    if vflip:
+        projections = projections.copy()
+        projections = projections[:, :, ::-1, :]
+
+    if gpuids is None:
+        gpuids = GpuIds()
+
+    if geox.nVoxel[0] < len(gpuids):
+        gpuids.devices = list(gpuids.devices[0 : geox.nVoxel[0]])
+
+    volumes = _Atb_multi_channel_ext(projections, geox, geox.angles, gpuids)
+
+    if output_order == "channels_xyz":
+        return np.transpose(volumes, (0, 3, 2, 1))
+    if output_order == "channels_zyx":
+        return volumes
+
+    raise ValueError(f"Unsupported output order: {output_order}")

--- a/Python/tigre/utilities/cuda_interface/_Atb_multi_channel.pyx
+++ b/Python/tigre/utilities/cuda_interface/_Atb_multi_channel.pyx
@@ -1,0 +1,86 @@
+cimport numpy as np
+import numpy as np
+
+from tigre.utilities.cuda_interface._types cimport Geometry as c_Geometry, convert_to_c_geometry, free_c_geometry
+from tigre.utilities.cuda_interface._gpuUtils cimport GpuIds as c_GpuIds, convert_to_c_gpuids, free_c_gpuids
+
+np.import_array()
+
+from libc.stdlib cimport malloc, free
+from tigre.utilities.errors import TigreCudaCallError
+
+cdef extern from "numpy/arrayobject.h":
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+
+cdef extern from "multi_channel_backprojection.hpp":
+    cdef int voxel_backprojection_multi_channel(float* projections,
+                                                c_Geometry geo,
+                                                float* result,
+                                                float const* alphas,
+                                                int nalpha,
+                                                int nChannels,
+                                                const c_GpuIds& gpuids)
+
+
+def cuda_raise_errors(error_code):
+    if error_code:
+        raise TigreCudaCallError('Atb_multi_channel:', error_code)
+
+
+def _Atb_multi_channel_ext(np.ndarray[np.float32_t, ndim=4] projections,
+                           geometry,
+                           np.ndarray[np.float32_t, ndim=2] angles,
+                           gpuids=None):
+    cdef int total_projections = angles.shape[0]
+    cdef int nChannels = projections.shape[1]
+
+    cdef c_GpuIds* c_gpuids = convert_to_c_gpuids(gpuids)
+    if not c_gpuids:
+        raise MemoryError("Error loading gpuIds")
+
+    cdef c_Geometry* c_geometry = convert_to_c_geometry(geometry, total_projections)
+
+    angles = np.ascontiguousarray(angles)
+    projections = np.ascontiguousarray(projections)
+
+    cdef float* c_angles = <float*> angles.data
+    cdef float* c_projections = <float*> projections.data
+
+    cdef unsigned long long voxels_per_channel = <unsigned long long>geometry.nVoxel[0] * <unsigned long long>geometry.nVoxel[1] * <unsigned long long>geometry.nVoxel[2]
+    cdef float* c_model = <float*> malloc(voxels_per_channel * <unsigned long long>nChannels * sizeof(float))
+    if not c_model:
+        free_c_geometry(c_geometry)
+        free_c_gpuids(c_gpuids)
+        raise MemoryError("Unable to allocate volume buffer")
+
+    try:
+        cuda_raise_errors(
+            voxel_backprojection_multi_channel(
+                c_projections,
+                c_geometry[0],
+                c_model,
+                c_angles,
+                total_projections,
+                nChannels,
+                c_gpuids[0],
+            )
+        )
+    except Exception:
+        free_c_geometry(c_geometry)
+        free_c_gpuids(c_gpuids)
+        free(c_model)
+        raise
+
+    free_c_geometry(c_geometry)
+    free_c_gpuids(c_gpuids)
+
+    cdef np.npy_intp shape[4]
+    shape[0] = <np.npy_intp>nChannels
+    shape[1] = <np.npy_intp>(<np.npy_long>geometry.nVoxel[0])
+    shape[2] = <np.npy_intp>(<np.npy_long>geometry.nVoxel[1])
+    shape[3] = <np.npy_intp>(<np.npy_long>geometry.nVoxel[2])
+
+    model = np.PyArray_SimpleNewFromData(4, shape, np.NPY_FLOAT32, c_model)
+    PyArray_ENABLEFLAGS(model, np.NPY_ARRAY_OWNDATA)
+
+    return model

--- a/setup.py
+++ b/setup.py
@@ -408,6 +408,32 @@ Atb_ext = Extension(
 )
 
 
+Atb_multi_channel_ext = Extension(
+    "_Atb_multi_channel",
+    sources=include_headers(
+        [
+            "Common/CUDA/TIGRE_common.cpp",
+            "Common/CUDA/GpuIds.cpp",
+            "Common/CUDA/gpuUtils.cu",
+            "CustomOperators/multi_channel_backprojection/multi_channel_backprojection.cu",
+            "Python/tigre/utilities/cuda_interface/_Atb_multi_channel.pyx",
+        ],
+        sdist=sys.argv[1] == "sdist",
+    ),
+    define_macros=define_macros,
+    library_dirs=[CUDA["lib64"]],
+    libraries=["cudart"],
+    language="c++",
+    runtime_library_dirs=[CUDA["lib64"]] if not IS_WINDOWS else None,
+    include_dirs=[
+        NUMPY_INCLUDE,
+        CUDA["include"],
+        "Common/CUDA/",
+        "CustomOperators/multi_channel_backprojection",
+    ],
+)
+
+
 tv_proximal_ext = Extension(
     "_tv_proximal",
     sources=include_headers(
@@ -513,7 +539,16 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     data_files=[("data", ["Common/data/head.mat"])],
-    ext_modules=[Ax_ext, Atb_ext, tv_proximal_ext, minTV_ext, AwminTV_ext, gpuUtils_ext, RandomNumberGenerator_ext],
+    ext_modules=[
+        Ax_ext,
+        Atb_ext,
+        Atb_multi_channel_ext,
+        tv_proximal_ext,
+        minTV_ext,
+        AwminTV_ext,
+        gpuUtils_ext,
+        RandomNumberGenerator_ext,
+    ],
     py_modules=["tigre.py"],
     cmdclass={"build_ext": BuildExtension},
     # since the package has c code, the egg cannot be zipped


### PR DESCRIPTION
## Summary
- add a Cython extension and Python helper that expose the multi-channel backprojection kernel as tigre.Atb_multi_channel
- register the new CUDA extension in the build system and re-export the helper from the tigre package
- document editable install usage and ship an example script that compares the multi-channel operator with a channel-wise loop

## Testing
- python -m compileall Python/tigre/utilities/Atb_multi_channel.py CustomOperators/multi_channel_backprojection/example_compare.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a95790ac8331bf451f47034ab514